### PR TITLE
Chat channel create fix

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Social/ChatManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Social/ChatManager.cs
@@ -3,11 +3,13 @@ using NexusForever.WorldServer.Game.Entity;
 using NexusForever.WorldServer.Game.Social.Static;
 using NexusForever.WorldServer.Game.TextFilter;
 using NexusForever.WorldServer.Game.TextFilter.Static;
+using NLog;
 
 namespace NexusForever.WorldServer.Game.Social
 {
     public class ChatManager
     {
+        private static readonly ILogger log = LogManager.GetCurrentClassLogger();
         private readonly Player owner;
         private readonly Dictionary<ulong, ChatChannel> channels = new();
 
@@ -44,6 +46,7 @@ namespace NexusForever.WorldServer.Game.Social
         /// </summary>
         public ChatResult CanJoin(string name, string password)
         {
+            log.Info($"{owner.Name} trying to join chat channel: {name}, password= {password}");
             if (!TextFilterManager.Instance.IsTextValid(name)
                 || !TextFilterManager.Instance.IsTextValid(name, UserText.ChatCustomChannelName))
                 return ChatResult.InvalidPasswordText;

--- a/Source/NexusForever.WorldServer/Game/Social/GlobalChatManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Social/GlobalChatManager.cs
@@ -171,7 +171,7 @@ namespace NexusForever.WorldServer.Game.Social
         /// </summary>
         public ChatChannel CreateChatChannel(ChatChannelType type, string name, string password = null)
         {
-            ulong id = chatChannelIds[type]++;
+            ulong id = (ulong) chatChannels[type].Count;
             return CreateChatChannel(type, id, name, password);
         }
 
@@ -180,6 +180,7 @@ namespace NexusForever.WorldServer.Game.Social
         /// </summary>
         public ChatChannel CreateChatChannel(ChatChannelType type, ulong id, string name, string password = null)
         {
+            log.Info($"Trying to create chat channel: (id {id}) {name}, password= {password}");
             if (chatChannelNames[type].TryGetValue(name, out ulong chatId))
             {
                 if (!chatChannels[type].TryGetValue(chatId, out ChatChannel channel) || !channel.PendingDelete)


### PR DESCRIPTION
Initial quick and dirty fix for errors when trying to create new custom chat channels.
The issue relates to how existing chat channels are loaded into hash maps in session for the player. Errors on key uniqueness happen when trying to create a new channel.

I changed it so the ID being assigned is the next ID after the last key in the player's hash map, but this could probably still cause errors if other players are creating new channels during that session.
There might need to be a pull from the database to get all existing channels again before trying to come up with the new ID.